### PR TITLE
Trigger op callbacks regardless for unhandled types in consume_batch_queue() et.al.

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -3838,7 +3838,15 @@ rd_kafka_poll_cb (rd_kafka_t *rk, rd_kafka_q_t *rkq, rd_kafka_op_t *rko,
                 break;
 
         default:
-                rd_kafka_assert(rk, !*"cant handle op type");
+                /* If op has a callback set (e.g., OAUTHBEARER_REFRESH),
+                 * call it. */
+                if (rko->rko_type & RD_KAFKA_OP_CB) {
+                        res = rd_kafka_op_call(rk, rkq, rko);
+                        break;
+                }
+
+                RD_BUG("Can't handle op type %s (0x%x)",
+                       rd_kafka_op2str(rko->rko_type), rko->rko_type);
                 break;
         }
 


### PR DESCRIPTION
Backport of https://github.com/edenhill/librdkafka/commit/bead2e4acc8f0723fa44d21451f85859d0da76e0

Note that changes in `CHANGELOG.md` and tests are not included here.

Fixes https://github.com/ClickHouse/ClickHouse/issues/38151
