### PR TITLE
Do not set _POSIX_C_SOURCE for FreeBSD (makes clang-15 happy)

### DIFF
--- a/src/rd.h
+++ b/src/rd.h
@@ -40,8 +40,10 @@
 #endif
 
 #define __need_IOV_MAX
+#if defined(__sun)
 #ifndef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L  /* for timespec on solaris */
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
Since this hides some symbols, like INADDR_LOOPBACK, gettimeofday(), alloca(), ...

CI: https://s3.amazonaws.com/clickhouse-builds/41046/8319a3d7b8837ec2c2334a41f11ccecee314d823/binary_freebsd/build_log.log
Refs: https://github.com/ClickHouse/ClickHouse/pull/41046