### PR TITLE
Fix data race in timers

### DIFF
--- a/src/rdkafka_timer.c
+++ b/src/rdkafka_timer.c
@@ -352,9 +352,12 @@ void rd_kafka_timers_run(rd_kafka_timers_t *rkts, int timeout_us) {
                         if ((oneshot = rtmr->rtmr_oneshot))
                                 rtmr->rtmr_interval = 0;
 
+                        void (*callback)(rd_kafka_timers_t *rkts, void *arg) = rtmr->rtmr_callback;
+                        void *arg = rtmr->rtmr_arg;
+
                         rd_kafka_timers_unlock(rkts);
 
-                        rtmr->rtmr_callback(rkts, rtmr->rtmr_arg);
+                        callback(rkts, arg);
 
                         rd_kafka_timers_lock(rkts);
 


### PR DESCRIPTION
Same as https://github.com/confluentinc/librdkafka/pull/5089 but for our fork.