### PR TITLE
Fix lock-order-inversion in queue refcount operations

### DIFF
--- a/HOW_TO_UPDATE.md
+++ b/HOW_TO_UPDATE.md
@@ -19,6 +19,7 @@ https://github.com/confluentinc/librdkafka/compare/master...ClickHouse:librdkafk
 * https://github.com/confluentinc/librdkafka/pull/4788
 * https://github.com/confluentinc/librdkafka/pull/5089
 * https://github.com/confluentinc/librdkafka/pull/5266
+* https://github.com/ClickHouse/librdkafka/pull/15 - Fix lock-order-inversion in queue refcount operations (use atomic refcount instead of mutex-protected)
 
 ### ClickHouse-specific fixes for 2.8 (cannot be upstreamed)
 

--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -88,9 +88,9 @@ void rd_kafka_q_init0(rd_kafka_q_t *rkq,
                       const char *func,
                       int line) {
         rd_kafka_q_reset(rkq);
-        rkq->rkq_fwdq   = NULL;
-        rkq->rkq_refcnt = 1;
-        rkq->rkq_flags  = RD_KAFKA_Q_F_READY;
+        rkq->rkq_fwdq = NULL;
+        rd_atomic32_init(&rkq->rkq_refcnt, 1);
+        rkq->rkq_flags = RD_KAFKA_Q_F_READY;
         if (for_consume)
                 rkq->rkq_flags |= RD_KAFKA_Q_F_CONSUMER;
         rkq->rkq_rk     = rk;
@@ -1105,8 +1105,8 @@ void rd_kafka_q_dump(FILE *fp, rd_kafka_q_t *rkq) {
         fprintf(fp,
                 "Queue %p \"%s\" (refcnt %d, flags 0x%x, %d ops, "
                 "%" PRId64 " bytes)\n",
-                rkq, rkq->rkq_name, rkq->rkq_refcnt, rkq->rkq_flags,
-                rkq->rkq_qlen, rkq->rkq_qsize);
+                rkq, rkq->rkq_name, rd_atomic32_get(&rkq->rkq_refcnt),
+                rkq->rkq_flags, rkq->rkq_qlen, rkq->rkq_qsize);
 
         if (rkq->rkq_qio)
                 fprintf(fp, " QIO fd %d\n", (int)rkq->rkq_qio->fd);

--- a/src/rdkafka_queue.h
+++ b/src/rdkafka_queue.h
@@ -60,7 +60,7 @@ struct rd_kafka_q_s {
         struct rd_kafka_op_tailq rkq_q; /* TAILQ_HEAD(, rd_kafka_op_s) */
         int rkq_qlen;                   /* Number of entries in queue */
         int64_t rkq_qsize;              /* Size of all entries in queue */
-        int rkq_refcnt;
+        rd_atomic32_t rkq_refcnt;
         int rkq_flags;
 #define RD_KAFKA_Q_F_ALLOCATED 0x1 /* Allocated: rd_free on destroy */
 #define RD_KAFKA_Q_F_READY                                                     \
@@ -149,15 +149,7 @@ void rd_kafka_q_destroy_final(rd_kafka_q_t *rkq);
 #define rd_kafka_q_unlock(rkqu) mtx_unlock(&(rkqu)->rkq_lock)
 
 static RD_INLINE RD_UNUSED rd_kafka_q_t *rd_kafka_q_keep(rd_kafka_q_t *rkq) {
-        mtx_lock(&rkq->rkq_lock);
-        rkq->rkq_refcnt++;
-        mtx_unlock(&rkq->rkq_lock);
-        return rkq;
-}
-
-static RD_INLINE RD_UNUSED rd_kafka_q_t *
-rd_kafka_q_keep_nolock(rd_kafka_q_t *rkq) {
-        rkq->rkq_refcnt++;
+        rd_atomic32_add(&rkq->rkq_refcnt, 1);
         return rkq;
 }
 
@@ -212,7 +204,7 @@ void rd_kafka_q_purge_toppar_version(rd_kafka_q_t *rkq,
  */
 static RD_INLINE RD_UNUSED void rd_kafka_q_destroy0(rd_kafka_q_t *rkq,
                                                     int disable) {
-        int do_delete = 0;
+        int32_t refcnt;
 
         if (disable) {
                 /* To avoid recursive locking (from ops being purged
@@ -223,12 +215,10 @@ static RD_INLINE RD_UNUSED void rd_kafka_q_destroy0(rd_kafka_q_t *rkq,
                 rd_kafka_q_purge0(rkq, 1 /*lock*/);
         }
 
-        mtx_lock(&rkq->rkq_lock);
-        rd_kafka_assert(NULL, rkq->rkq_refcnt > 0);
-        do_delete = !--rkq->rkq_refcnt;
-        mtx_unlock(&rkq->rkq_lock);
+        refcnt = rd_atomic32_sub(&rkq->rkq_refcnt, 1);
+        rd_kafka_assert(NULL, refcnt >= 0);
 
-        if (unlikely(do_delete))
+        if (unlikely(refcnt == 0))
                 rd_kafka_q_destroy_final(rkq);
 }
 
@@ -362,7 +352,7 @@ static RD_INLINE RD_UNUSED void rd_kafka_q_yield(rd_kafka_q_t *rkq) {
 
         mtx_lock(&rkq->rkq_lock);
 
-        rd_dassert(rkq->rkq_refcnt > 0);
+        rd_dassert(rd_atomic32_get(&rkq->rkq_refcnt) > 0);
 
         if (unlikely(!(rkq->rkq_flags & RD_KAFKA_Q_F_READY))) {
                 /* Queue has been disabled */
@@ -429,7 +419,7 @@ static RD_INLINE RD_UNUSED int rd_kafka_q_enq1(rd_kafka_q_t *rkq,
         if (do_lock)
                 mtx_lock(&rkq->rkq_lock);
 
-        rd_dassert(rkq->rkq_refcnt > 0);
+        rd_dassert(rd_atomic32_get(&rkq->rkq_refcnt) > 0);
 
         if (unlikely(!(rkq->rkq_flags & RD_KAFKA_Q_F_READY))) {
                 /* Queue has been disabled, reply to and fail the rko. */


### PR DESCRIPTION
Attempt to fix:
https://github.com/ClickHouse/ClickHouse/issues/84144
https://github.com/confluentinc/librdkafka/issues/4782

Change queue refcount from mutex-protected `int` to `rd_atomic32_t` to eliminate lock-order-inversion detected by ThreadSanitizer.

The issue occurred when:
- Thread A held queue A's lock and called `rd_kafka_q_fwd_get` which called `rd_kafka_q_keep` on queue B, trying to acquire B's lock
- Thread B held queue B's lock and during op destruction tried to acquire queue A's lock via `rd_kafka_q_disable0`

This created an ABBA deadlock pattern.

The fix makes refcount operations lock-free by using atomic operations, eliminating the need for `rd_kafka_q_keep` to acquire any locks.

Changes:
- Change `int rkq_refcnt` to `rd_atomic32_t rkq_refcnt`
- Use `rd_atomic32_add` in `rd_kafka_q_keep`
- Use `rd_atomic32_sub` in `rd_kafka_q_destroy0`
- Use `rd_atomic32_get` for assertions and debug output
- Use `rd_atomic32_init` for initialization
- Remove redundant `rd_kafka_q_keep_nolock` function