### PR TITLE
Fix lock-order-inversion in rd_kafka_q_concat0 and rd_kafka_q_prepend0

### DIFF
--- a/src/rdkafka_queue.h
+++ b/src/rdkafka_queue.h
@@ -567,11 +567,20 @@ rd_kafka_q_concat0(rd_kafka_q_t *rkq, rd_kafka_q_t *srcq, int do_lock) {
 
                 rd_kafka_q_mark_served(srcq);
                 rd_kafka_q_reset(srcq);
-        } else
-                r = rd_kafka_q_concat0(rkq->rkq_fwdq ? rkq->rkq_fwdq : rkq,
-                                       srcq, rkq->rkq_fwdq ? do_lock : 0);
-        if (do_lock)
-                mtx_unlock(&rkq->rkq_lock);
+                if (do_lock)
+                        mtx_unlock(&rkq->rkq_lock);
+        } else {
+                /* Queue is being forwarded. To avoid lock-order-inversion
+                 * (potential deadlock), release the current queue's lock
+                 * before locking the forwarded queue.
+                 * Same pattern as rd_kafka_q_enq1(). */
+                rd_kafka_q_t *fwdq = rkq->rkq_fwdq;
+                rd_kafka_q_keep(fwdq);
+                if (do_lock)
+                        mtx_unlock(&rkq->rkq_lock);
+                r = rd_kafka_q_concat0(fwdq, srcq, 1 /*do_lock*/);
+                rd_kafka_q_destroy(fwdq);
+        }
 
         return r;
 }
@@ -606,12 +615,28 @@ rd_kafka_q_prepend0(rd_kafka_q_t *rkq, rd_kafka_q_t *srcq, int do_lock) {
 
                 rd_kafka_q_mark_served(srcq);
                 rd_kafka_q_reset(srcq);
-        } else
-                rd_kafka_q_prepend0(rkq->rkq_fwdq ? rkq->rkq_fwdq : rkq,
+                if (do_lock)
+                        mtx_unlock(&rkq->rkq_lock);
+        } else if (rkq->rkq_fwdq) {
+                /* Destination queue is being forwarded. To avoid
+                 * lock-order-inversion (potential deadlock), release the
+                 * current queue's lock before locking the forwarded queue.
+                 * Same pattern as rd_kafka_q_enq1(). */
+                rd_kafka_q_t *fwdq = rkq->rkq_fwdq;
+                rd_kafka_q_keep(fwdq);
+                if (do_lock)
+                        mtx_unlock(&rkq->rkq_lock);
+                rd_kafka_q_prepend0(fwdq,
                                     srcq->rkq_fwdq ? srcq->rkq_fwdq : srcq,
-                                    rkq->rkq_fwdq ? do_lock : 0);
-        if (do_lock)
-                mtx_unlock(&rkq->rkq_lock);
+                                    1 /*do_lock*/);
+                rd_kafka_q_destroy(fwdq);
+        } else {
+                /* Only source queue is forwarded, no nested locking needed
+                 * since we recurse on the same rkq without re-locking. */
+                rd_kafka_q_prepend0(rkq, srcq->rkq_fwdq, 0 /*already locked*/);
+                if (do_lock)
+                        mtx_unlock(&rkq->rkq_lock);
+        }
 }
 
 #define rd_kafka_q_prepend(dstq, srcq)                                         \


### PR DESCRIPTION
Fix lock-order-inversion (potential deadlock) detected by ThreadSanitizer in `rd_kafka_q_concat0` and `rd_kafka_q_prepend0`.

## Problem

The deadlock cycle involves two mutexes M0 and M1:

**Thread A (broker thread):** `rd_kafka_q_concat0` locks M0, then recursively calls itself on the forwarded queue M1, trying to lock M1 while holding M0.

**Thread B (server thread, during shutdown):** `rd_kafka_q_pop_serve` holds M1's lock, and during `rd_kafka_op_filter` → `rd_kafka_toppar_destroy_final` → `rd_kafka_q_destroy_owner` → `rd_kafka_q_disable0`, tries to acquire M0's lock.

This creates an ABBA deadlock: Thread A holds M0 and wants M1; Thread B holds M1 and wants M0.

## Fix

Follow the same pattern already used by `rd_kafka_q_enq1`: get a reference to the forwarded queue via `rd_kafka_q_keep` (lock-free since the atomic refcount fix in #15), release the current queue's lock, recurse on the forwarded queue, then release the reference.

Complementary to #15 which fixed a different code path (`rd_kafka_q_len` → `rd_kafka_q_fwd_get` → `rd_kafka_q_keep`) with the same ABBA deadlock class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)