### PR TITLE
Fix use-after-free in consumer lag timer

### DIFF
--- a/HOW_TO_UPDATE.md
+++ b/HOW_TO_UPDATE.md
@@ -23,6 +23,14 @@ https://github.com/confluentinc/librdkafka/compare/master...ClickHouse:librdkafk
 
 ### ClickHouse-specific fixes for 2.8 (cannot be upstreamed)
 
+* Fix heap-use-after-free in `rd_kafka_toppar_consumer_lag_tmr_cb`: acquire a
+  reference when starting the consumer lag timer (`rd_kafka_toppar_new0`) and
+  release it in `rd_kafka_cgrp_partition_del` (which runs on the same KafkaMain
+  thread as the timer callback, so no callback can be in-flight when the
+  reference is released). Without this, the KafkaBroker thread can free the
+  toppar between the timer capturing its `arg` pointer and the callback
+  actually running.
+
 * Calling 'kafka_' prefixed versions of cJSON to avoid clashes with aws-c-common's version of cJSON:
 
     https://github.com/ClickHouse/ClickHouse/pull/94343

--- a/HOW_TO_UPDATE.md
+++ b/HOW_TO_UPDATE.md
@@ -25,11 +25,12 @@ https://github.com/confluentinc/librdkafka/compare/master...ClickHouse:librdkafk
 
 * Fix heap-use-after-free in `rd_kafka_toppar_consumer_lag_tmr_cb`: acquire a
   reference when starting the consumer lag timer (`rd_kafka_toppar_new0`) and
-  release it in `rd_kafka_cgrp_partition_del` (which runs on the same KafkaMain
-  thread as the timer callback, so no callback can be in-flight when the
-  reference is released). Without this, the KafkaBroker thread can free the
-  toppar between the timer capturing its `arg` pointer and the callback
-  actually running.
+  release it in `rd_kafka_cgrp_partition_del` (for cgrp partitions) and in
+  `rd_kafka_topic_partitions_remove` (for all remaining partitions during
+  shutdown). Both release points run on the KafkaMain thread, so no timer
+  callback can be in-flight when the reference is released. Without this, the
+  KafkaBroker thread can free the toppar between the timer capturing its `arg`
+  pointer and the callback actually running.
 
 * Calling 'kafka_' prefixed versions of cJSON to avoid clashes with aws-c-common's version of cJSON:
 

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -3489,6 +3489,17 @@ static void rd_kafka_cgrp_partition_del(rd_kafka_cgrp_t *rkcg,
 
         rd_list_remove(&rkcg->rkcg_toppars, rktp);
 
+        /* Stop the consumer lag timer and release its reference before
+         * releasing the cgrp reference. Both this function and the timer
+         * callback run on the KafkaMain thread, so stopping the timer here
+         * guarantees no callback is in flight when we release the references.
+         * Without this, the broker thread can free the toppar between the
+         * timer capturing its arg pointer and the callback actually running,
+         * causing a heap-use-after-free. */
+        if (rd_kafka_timer_stop(&rktp->rktp_rkt->rkt_rk->rk_timers,
+                                &rktp->rktp_consumer_lag_tmr, 1 /*lock*/))
+                rd_kafka_toppar_destroy(rktp); /* refcnt from timer keep */
+
         rd_kafka_toppar_destroy(rktp); /* refcnt from _add above */
 
         rd_kafka_cgrp_try_terminate(rkcg);

--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -283,7 +283,8 @@ rd_kafka_toppar_t *rd_kafka_toppar_new0(rd_kafka_topic_t *rkt,
                         intvl = 10 * 1000;
                 rd_kafka_timer_start(
                     &rkt->rkt_rk->rk_timers, &rktp->rktp_consumer_lag_tmr,
-                    intvl * 1000ll, rd_kafka_toppar_consumer_lag_tmr_cb, rktp);
+                    intvl * 1000ll, rd_kafka_toppar_consumer_lag_tmr_cb,
+                    rd_kafka_toppar_keep(rktp));
         }
 
         rktp->rktp_rkt = rd_kafka_topic_keep(rkt);

--- a/src/rdkafka_topic.c
+++ b/src/rdkafka_topic.c
@@ -1535,6 +1535,17 @@ void rd_kafka_topic_partitions_remove(rd_kafka_topic_t *rkt) {
                 rd_kafka_toppar_purge_and_disable_queues(rktp);
                 rd_kafka_toppar_unlock(rktp);
 
+                /* Stop the consumer lag timer and release its reference.
+                 * For cgrp partitions the timer was already stopped in
+                 * rd_kafka_cgrp_partition_del so timer_stop returns 0.
+                 * This call runs on the main thread after the main loop
+                 * has exited, so no timer callback can be in flight. */
+                if (rd_kafka_timer_stop(&rkt->rkt_rk->rk_timers,
+                                        &rktp->rktp_consumer_lag_tmr,
+                                        1 /*lock*/))
+                        rd_kafka_toppar_destroy(rktp); /* refcnt from
+                                                        * timer keep */
+
                 rd_kafka_toppar_destroy(rktp);
         }
         rd_list_destroy(partitions);


### PR DESCRIPTION
The race is claimed to be here:

https://github.com/ClickHouse/librdkafka/blob/0baf1b41d68ccec4211ba60afc98173d4c9bc2a0/src/rdkafka_timer.c#L355-L362

Before we call the `callback`, the `arg` — a topic partition object may be destroyed, because no additional reference is acquired. And the proposed solution was to acquire an additional reference when starting a timer.

---

The failure example: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97943&sha=d9c41220fc4185d8e330e9af40ca4414cb29589a&name_0=PR&name_1=Integration%20tests%20%28amd_asan%2C%20db%20disk%2C%20old%20analyzer%2C%201%2F6%29