### PR TITLE
Use bounded timeout in rd_kafka_assign0 instead of RD_POLL_INFINITE

### DIFF
--- a/src/rdkafka_subscription.c
+++ b/src/rdkafka_subscription.c
@@ -119,8 +119,27 @@ rd_kafka_assign0(rd_kafka_t *rk,
                 rko->rko_u.assign.partitions =
                     rd_kafka_topic_partition_list_copy(partitions);
 
+        /* Use a bounded timeout (30s) instead of RD_POLL_INFINITE.
+         *
+         * rd_kafka_assign() is called from the rebalance callback,
+         * which fires inside rd_kafka_consumer_poll/poll_batch on the
+         * application thread.  It sends an RD_KAFKA_OP_ASSIGN to the
+         * consumer-group background thread and waits for a reply.
+         *
+         * With RD_POLL_INFINITE the wait is unbounded: if the cgrp
+         * thread is blocked (e.g. waiting for a coordinator while the
+         * broker is temporarily unreachable after a pause/unpause
+         * cycle), the application thread hangs inside poll_batch()
+         * for an arbitrarily long time — far exceeding the poll
+         * timeout the caller requested.  This makes it impossible to
+         * cancel or shut down the consumer promptly.
+         *
+         * A 30 s cap is generous enough for any healthy rebalance
+         * while still letting the caller regain control and react to
+         * shutdown signals.  On timeout rd_kafka_op_error_destroy()
+         * returns RD_KAFKA_RESP_ERR__TIMED_OUT. */
         return rd_kafka_op_error_destroy(
-            rd_kafka_op_req(rkcg->rkcg_ops, rko, RD_POLL_INFINITE));
+            rd_kafka_op_req(rkcg->rkcg_ops, rko, 30 * 1000));
 }
 
 


### PR DESCRIPTION
## Summary

`rd_kafka_assign()` is called from the rebalance callback, which fires inside `rd_kafka_consumer_poll` / `poll_batch` on the application thread. It sends an `RD_KAFKA_OP_ASSIGN` to the consumer-group background thread via `rd_kafka_op_req` with `RD_POLL_INFINITE`.

If the cgrp thread is blocked (e.g. waiting for a coordinator while the broker is temporarily unreachable after a network interruption), the application thread hangs inside `poll_batch()` for an arbitrarily long time — far exceeding the poll timeout the caller requested. This makes it impossible to cancel or shut down the consumer promptly.

Replace `RD_POLL_INFINITE` with a 30-second timeout. This is generous enough for any healthy rebalance while still letting the caller regain control and react to shutdown signals. On timeout, `rd_kafka_op_error_destroy` returns `RD_KAFKA_RESP_ERR__TIMED_OUT`.

### Root cause chain

```
poll_batch(timeout=500ms)
  → rd_kafka_consume_batch_queue()
    → rd_kafka_q_serve_rkmessages()
      → rd_kafka_poll_cb()            // serves rebalance callback
        → Consumer::handle_rebalance()
          → Consumer::assign()
            → rd_kafka_assign()
              → rd_kafka_assign0()
                → rd_kafka_op_req(cgrp_ops, rko, RD_POLL_INFINITE)
                  → rd_kafka_q_pop(recvq, INFINITE)  ← blocks forever
```